### PR TITLE
add an index on ExpirationDate, for /json and pruning

### DIFF
--- a/iplimit.sql
+++ b/iplimit.sql
@@ -3,6 +3,7 @@ CREATE TABLE `Exception` (
   `CreationDate` datetime NOT NULL,
   `ExpirationDate` datetime NOT NULL,
   `Requestor` varchar(100) DEFAULT NULL,
-  PRIMARY KEY (`ExceptionIP`)
+  PRIMARY KEY (`ExceptionIP`),
+  KEY (`ExpirationDate`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
The app does two kinds of queries, `WHERE pkey = ?` and `WHERE ExpirationDate > ?` (and someday, `WHERE ExpirationDate < ?`). There's no index on ExpirationDate, so this fixes that. And none of the queries in the app use multiple column WHERE clauses, so this is sufficient.
